### PR TITLE
docs: add architecture overview with telemetry to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,62 @@ A TypeScript monorepo for open-forge packages.
 | [`@open-forge/mcp`](packages/mcp)             | MCP server implementation for OpenSpec archives                                                                                            |
 | [`@open-forge/telemetry`](packages/telemetry) | Telemetry and constraint evaluation for open-forge pipeline stages                                                                         |
 
+## Architecture Overview
+
+Open Forge is an autonomous software development pipeline. You give it a description of what you want built, and it runs a multi-phase agent workflow to produce working code with quality enforcement at every step.
+
+```
+Requirements (text)
+       │
+       ▼
+┌─────────────┐
+│ Intent Router│ ── Classifies: new-project / feature / bug-fix / refactor / migration
+└──────┬──────┘
+       │
+       ▼
+┌──────────────┐
+│ ROADMAP Gen  │ ── Produces phased, dependency-ordered task plan
+└──────┬───────┘
+       │
+       ▼
+┌──────────────────────────────────────────────────┐
+│ Pipeline Orchestrator (per phase)                 │
+│                                                   │
+│  1. Read HANDOFF.md (restore context)             │
+│  2. Generate & select plan (critic agent)         │
+│  3. Write tests (test author — firewalled)        │
+│  4. Implement (implementer — firewalled)          │
+│  5. Quality gates (verify → QA → security →       │
+│     architect → code review → integration)        │
+│  6. Cleanup agent (entropy management)            │
+│  7. Update HANDOFF.md (persist context)           │
+│                                                   │
+│  On failure: retry up to 3x → drift sentinel     │
+│  On success: advance to next phase                │
+├──────────────────────────────────────────────────┤
+│ ⚡ Telemetry (@open-forge/telemetry)              │
+│                                                   │
+│  • Captures structured events from every stage    │
+│  • Evaluates constraints (token budget, retries,  │
+│    duration limits) after each stage              │
+│  • Halts pipeline on constraint violations        │
+│  • Generates audit trails for human review        │
+└──────────────────────────────────────────────────┘
+       │
+       ▼
+  ROADMAP_COMPLETE (or PIPELINE-ISSUES.md for blockers)
+```
+
+### Key Design Principles
+
+- **Context firewalls** — The test-writing agent and the implementing agent are deliberately isolated from each other to prevent hallucination reinforcement
+- **Self-correction loops** — When quality gates fail, the system retries up to 3x before escalating to a human via `PIPELINE-ISSUES.md`
+- **Drift detection** — If an agent gets stuck in a loop, a sentinel file is written and execution halts rather than burning tokens
+- **Constraint enforcement** — Telemetry evaluates token budgets, retry limits, and duration caps after every stage, providing a hard stop before costs spiral
+- **Lessons feedback** — Recurring mistakes from gate failures are captured in `LESSONS.md` and fed to future agents
+
+For the full design — including context firewall rules, gate sequences, and guardrails — see the [pipeline REQUIREMENTS.md](packages/pipeline/REQUIREMENTS.md). For telemetry constraint definitions, see the [telemetry requirements](docs/open-forge-telemetry-REQUIREMENTS.md).
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Adds the pipeline architecture diagram and key design principles to the root README so visitors understand how the system operates at a glance.

The diagram is updated from the pipeline README to show where `@open-forge/telemetry` fits — as a cross-cutting layer that captures events from every pipeline stage and enforces constraints (token budgets, retry limits, duration caps).

The MCP server is intentionally excluded from the diagram since it's a standalone tool for AI assistants to access OpenSpec archives, not part of the pipeline execution flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Architecture Overview" section describing Open Forge's multi-phase autonomous pipeline workflow, including requirements routing, roadmap generation, and per-phase orchestration with quality gates
  * Added "Key Design Principles" covering context firewalls, self-correction retries, drift detection, and telemetry-based constraints
  * Added references to related documentation resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->