### PR TITLE
fix: lint errors from new version of llm-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@vitest/coverage-v8": "4.0.9",
         "@vitest/ui": "4.0.9",
         "eslint": "~8.57.0",
-        "eslint-plugin-llm-core": "^0.8.0",
+        "eslint-plugin-llm-core": "^0.11.1",
         "husky": "^9.1.7",
         "jiti": "2.4.2",
         "jsonc-eslint-parser": "^2.1.0",
@@ -8118,9 +8118,9 @@
       }
     },
     "node_modules/eslint-plugin-llm-core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-llm-core/-/eslint-plugin-llm-core-0.8.0.tgz",
-      "integrity": "sha512-9E/J+qCsEfZaV7/q5j7TNlQB0Tz/G6vkGns3VlSbrlhYFX+xdp5lW7AH9cKucjQvrNaLn2FxYlRHUbD6h6rCCg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-llm-core/-/eslint-plugin-llm-core-0.11.1.tgz",
+      "integrity": "sha512-3YtQMqbJaB+Be4YxdxqrHlqWbfYsbOtj/MPAmgudkP57tMjSBaCAV0jh2jD7b/FjwofTG17gXG5z4jD/rc03Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@vitest/coverage-v8": "4.0.9",
     "@vitest/ui": "4.0.9",
     "eslint": "~8.57.0",
-    "eslint-plugin-llm-core": "^0.8.0",
+    "eslint-plugin-llm-core": "^0.11.1",
     "husky": "^9.1.7",
     "jiti": "2.4.2",
     "jsonc-eslint-parser": "^2.1.0",

--- a/packages/pipeline/src/lib/handoff/manager.ts
+++ b/packages/pipeline/src/lib/handoff/manager.ts
@@ -132,11 +132,11 @@ export async function writeHandoff(
 
   try {
     await writeFile(filePath, markdown, 'utf-8');
-  } catch (err) {
+  } catch (error) {
     throw new HandoffWriteError(
       filePath,
       `Failed to write HANDOFF.md: ${
-        err instanceof Error ? err.message : String(err)
+        error instanceof Error ? error.message : String(error)
       }`
     );
   }

--- a/packages/pipeline/src/lib/helper/checkpoint.ts
+++ b/packages/pipeline/src/lib/helper/checkpoint.ts
@@ -71,18 +71,17 @@ async function shadowGit(cmd: GitCommand): Promise<string> {
     ...process.env,
     GIT_DIR: cmd.gitDir,
   };
-  if (cmd.useWorkTree !== false) env.GIT_WORK_TREE = cmd.workDir;
+  if (cmd.useWorkTree ?? true) env.GIT_WORK_TREE = cmd.workDir;
   try {
     const { stdout } = await execFile('git', cmd.args, {
       env,
       cwd: cmd.workDir,
     });
     return stdout.trim();
-  } catch (err: unknown) {
-    const error = err as { stderr?: string };
+  } catch (error: unknown) {
     throw new CheckpointGitError(
       `git ${cmd.args.join(' ')}`,
-      error.stderr ?? String(err)
+      (error as { stderr?: string }).stderr ?? String(error)
     );
   }
 }

--- a/packages/pipeline/src/lib/helper/drift.ts
+++ b/packages/pipeline/src/lib/helper/drift.ts
@@ -151,18 +151,18 @@ export async function readDriftSentinel(
   let content: string;
   try {
     content = await readFile(filePath, 'utf-8');
-  } catch (err: unknown) {
+  } catch (error: unknown) {
     if (
-      err instanceof Error &&
-      'code' in err &&
-      (err as NodeJS.ErrnoException).code === 'ENOENT'
+      error instanceof Error &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
       throw new DriftSentinelError(
         filePath,
         `Drift sentinel file not found: ${filePath}`
       );
     }
-    throw err;
+    throw error;
   }
   return parse(content, filePath);
 }
@@ -174,15 +174,15 @@ export async function checkDriftSentinel(filePath: string): Promise<boolean> {
   try {
     await access(filePath);
     return true;
-  } catch (err: unknown) {
+  } catch (error: unknown) {
     if (
-      err instanceof Error &&
-      'code' in err &&
-      (err as NodeJS.ErrnoException).code === 'ENOENT'
+      error instanceof Error &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
       return false;
     }
-    throw err;
+    throw error;
   }
 }
 
@@ -192,14 +192,14 @@ export async function checkDriftSentinel(filePath: string): Promise<boolean> {
 export async function clearDriftSentinel(filePath: string): Promise<void> {
   try {
     await unlink(filePath);
-  } catch (err: unknown) {
+  } catch (error: unknown) {
     if (
-      err instanceof Error &&
-      'code' in err &&
-      (err as NodeJS.ErrnoException).code === 'ENOENT'
+      error instanceof Error &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
       return;
     }
-    throw err;
+    throw error;
   }
 }

--- a/packages/pipeline/tests/drift-sentinel.test.ts
+++ b/packages/pipeline/tests/drift-sentinel.test.ts
@@ -88,9 +88,9 @@ describe('readDriftSentinel', () => {
     try {
       await readDriftSentinel(filePath);
       expect.fail('should have thrown');
-    } catch (err) {
-      expect(err).toBeInstanceOf(DriftSentinelError);
-      expect((err as DriftSentinelError).filePath).toBe(filePath);
+    } catch (error) {
+      expect(error).toBeInstanceOf(DriftSentinelError);
+      expect((error as DriftSentinelError).filePath).toBe(filePath);
     }
   });
 });

--- a/packages/pipeline/tests/handoff-manager.test.ts
+++ b/packages/pipeline/tests/handoff-manager.test.ts
@@ -127,9 +127,9 @@ describe('readHandoff errors', () => {
     try {
       await readHandoff(filePath);
       expect.fail('should have thrown');
-    } catch (err) {
-      expect(err).toBeInstanceOf(HandoffReadError);
-      expect((err as HandoffReadError).filePath).toBe(filePath);
+    } catch (error) {
+      expect(error).toBeInstanceOf(HandoffReadError);
+      expect((error as HandoffReadError).filePath).toBe(filePath);
     }
   });
 

--- a/packages/telemetry/src/storage/FileStorageBackend.ts
+++ b/packages/telemetry/src/storage/FileStorageBackend.ts
@@ -34,9 +34,9 @@ export class FileStorageBackend implements StorageBackend {
     let content: string;
     try {
       content = await readFile(this.filePath, 'utf-8');
-    } catch (err: unknown) {
-      if (isNodeError(err) && err.code === 'ENOENT') return [];
-      throw err;
+    } catch (error: unknown) {
+      if (isNodeError(error) && error.code === 'ENOENT') return [];
+      throw error;
     }
 
     return content


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development ESLint plugin dependency from version 0.8.0 to 0.11.1, introducing new lint rules.
  * Standardized error handling patterns and variable naming across the codebase.
  * Modified work tree handling to default to enabled state when not explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->